### PR TITLE
Update OpenStack_Grizzly_Install_Guide.rst

### DIFF
--- a/OpenStack_Grizzly_Install_Guide.rst
+++ b/OpenStack_Grizzly_Install_Guide.rst
@@ -351,6 +351,7 @@ Status: On Going Work
 
    cd /etc/init.d/; for i in $( ls quantum-* ); do sudo service $i restart; done
    service dnsmasq restart
+* Note: 'dnsmasq' fails to restart if already a service is running on port 53. In that case, kill that service before 'dnsmasq' restart
 
 6. Nova
 ===========


### PR DESCRIPTION
“dnsmasq” restart fails as already service on port 53 is running
Ubuntu comes with default service running on port 53
In that case., we have to kill the process running on port 53 

Lets say:

netstat -anlp | grep -w LISTEN

tcp        0      0 10.42.43.1:53           0.0.0.0:\*               LISTEN      4489/dnsmasq

sudo kill 4489
