### PR TITLE
Fix HOST_IP in keystone_basic.sh

### DIFF
--- a/KeystoneScripts/keystone_basic.sh
+++ b/KeystoneScripts/keystone_basic.sh
@@ -9,7 +9,7 @@
 # Support: openstack@lists.launchpad.net
 # License: Apache Software License (ASL) 2.0
 #
-HOST_IP=100.10.10.51
+HOST_IP=10.10.100.51
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin_pass}
 SERVICE_PASSWORD=${SERVICE_PASSWORD:-service_pass}
 export SERVICE_TOKEN="ADMIN"


### PR DESCRIPTION
HOST_IP in keystone_basic.sh was incorrect in the OVS_SingleNode branch.
