### PR TITLE
Note added on dbus and libvirt-bin

### DIFF
--- a/OpenStack_Grizzly_Install_Guide.rst
+++ b/OpenStack_Grizzly_Install_Guide.rst
@@ -397,6 +397,10 @@ Status: Stable
 
    apt-get install -y kvm libvirt-bin pm-utils
 
+* Restart libvirt-bin and dbus, otherwise libvirt-bin will fail to start
+   
+   service dbus restart && service libvirt-bin restart
+
 * Edit the cgroup_device_acl array in the /etc/libvirt/qemu.conf file to::
 
    cgroup_device_acl = [


### PR DESCRIPTION
Although dbus is installed, it is not started and therefore libvirt-bin fails to start.
