### PR TITLE
13.04 has different path for quantum_sudoers file

### DIFF
--- a/OpenStack_Grizzly_Install_Guide.rst
+++ b/OpenStack_Grizzly_Install_Guide.rst
@@ -674,6 +674,8 @@ Status: Stable
    #Modify the quantum user
    quantum ALL=NOPASSWD: ALL
 
+  **Note :** For Ubuntu 13.04 the path is `/etc/sudoers.d/quantum_sudoers`
+  
 * Restart all the services::
 
    cd /etc/init.d/; for i in $( ls quantum-* ); do sudo service $i restart; done


### PR DESCRIPTION
I think this is necessary as most of the people will end up creating a new file without realizing it instead of updating the existing one.
