### PR TITLE
Update the  location of /etc/sudoers/sudoers.d/quantum_sudoers for Ubunt...

### DIFF
--- a/OpenStack_Grizzly_Install_Guide.rst
+++ b/OpenStack_Grizzly_Install_Guide.rst
@@ -670,6 +670,7 @@ Status: Stable
 * Edit /etc/sudoers/sudoers.d/quantum_sudoers to give it full access like this (This is unfortunatly mandatory) ::
 
    nano /etc/sudoers/sudoers.d/quantum_sudoers
+   # for Ubuntu 12.04 the location is /etc/sudoers.d/quantum_sudoers
    
    #Modify the quantum user
    quantum ALL=NOPASSWD: ALL


### PR DESCRIPTION
...u 12.04

While I was working I found the location of "quantum_sudoers" file should be "/etc/sudoers.d/" instead of "/etc/sudoers/sudoers.d/" because there is no folder named sudoers in /etc in Ubuntu 12.04
