### PR TITLE
Sudo -i, become root and load roots environment varibles. 

### DIFF
--- a/OpenStack_Grizzly_Install_Guide.rst
+++ b/OpenStack_Grizzly_Install_Guide.rst
@@ -77,7 +77,7 @@ Status: Stable
 
 * After you install Ubuntu 12.04 Server 64bits, Go in sudo mode and don't leave it until the end of this guide::
 
-   sudo su
+   sudo -i
 
 * Add Grizzly repositories::
 


### PR DESCRIPTION
"sudo su" is redundant and leaves the users env in place
