### PR TITLE
Update OpenStack_Grizzly_Install_Guide.rst

### DIFF
--- a/OpenStack_Grizzly_Install_Guide.rst
+++ b/OpenStack_Grizzly_Install_Guide.rst
@@ -655,6 +655,19 @@ Status: Stable
 
    metadata_proxy_shared_secret = helloOpenStack
 
+* Create new file /etc/quantum/dnsmasq.conf::
+   
+   # reduce the MTU on the new instances to 1454
+   dhcp-option-force=26,1454
+   log-facility = /var/log/quantum/dnsmasq.log
+   log-dhcp
+   
+   # Change file's owner 
+   chown root:quantum /etc/quantum/dnsmasq.conf
+   
+   #Add line to /etc/quantum/dhcp_agent.ini
+   dnsmasq_config_file = /etc/quantum/dnsmasq.conf
+   
 * Make sure that your rabbitMQ IP in /etc/quantum/quantum.conf is set to the controller node::
 
    rabbit_host = 10.10.10.51


### PR DESCRIPTION
MTU issues 
riduce MTU when you create a new instance  from default 1500 to 1454 
now the new instance able to have full access at internet

this doesn’t have effect to cirros3.1 because it has a bug but it's working with all other distro ,  ubuntu, fedora, debian..
